### PR TITLE
Update logo in README for non-github viewing and alt text

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # xWRF
 
-![Logo](docs/source/_static/xwrf_logo_bg_dark.svg#gh-dark-mode-only)![Logo](docs/source/_static/xwrf_logo_bg_light.svg#gh-light-mode-only)
+![Project logo displaying the name xWRF, with the X made of triangles pointing to a center point and tick marks bordering each letter](https://github.com/xarray-contrib/xwrf/raw/main/docs/source/_static/xwrf_logo_bg_light.svg#gh-light-mode-only)![](docs/source/_static/xwrf_logo_bg_dark.svg#gh-dark-mode-only)
 
 | CI          | [![GitHub Workflow Status][github-ci-badge]][github-ci-link] [![Code Coverage Status][codecov-badge]][codecov-link] [![pre-commit.ci status][pre-commit.ci-badge]][pre-commit.ci-link] |
 | :---------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: |


### PR DESCRIPTION
<!-- Thanks for submitting a PR, your contribution is really appreciated! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

## Change Summary

<!-- Please give a short summary of the changes. -->

In testing the release process with TestPyPI, I saw that the logo(s) in the README do not appear, as they currently use relative rather than absolute URLs:

![image](https://user-images.githubusercontent.com/3460034/189383792-e4f60516-9172-4a78-9d7f-82c8240852b6.png)

This updates one of the two logos (the light background) to use an absolute URL instead. I also took the chance to update the alt text to something more descriptive than just "Logo."

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

## Checklist

- ~~Unit tests for the changes exist~~
- ~~Tests pass on CI~~
- ~~Documentation reflects the changes where applicable~~

<!--
Please add any other relevant info below:
-->
