### PR TITLE
Fix destagger attrs

### DIFF
--- a/tests/test_accessors.py
+++ b/tests/test_accessors.py
@@ -110,5 +110,13 @@ def test_dataset_destagger(test_grid):
             or destaggered[varname].attrs['stagger'] == ''
         )
 
+    # Check preservation of variable attrs
+    for varname in set(test_grid.data_vars).intersection(set(destaggered.data_vars)):
+        # have to pop 'units' too, because dimensionless units have attr removed on postprocess
+        for key in ['stagger', 'units']:
+            if key in test_grid[varname].attrs:
+                test_grid[varname].attrs.pop(key)
+        assert set(test_grid[varname].attrs.keys()) <= set(destaggered[varname].attrs.keys())
+
     # Check that attrs are preserved
     assert destaggered.attrs == test_grid.attrs

--- a/tests/test_accessors.py
+++ b/tests/test_accessors.py
@@ -79,6 +79,11 @@ def test_dataarray_destagger(test_grid):
     xr.testing.assert_allclose(destaggered['XLAT'], test_grid['XLAT'])
     xr.testing.assert_allclose(destaggered['XLONG'], test_grid['XLONG'])
 
+    # Check attributes are preserved
+    if 'stagger' in data.attrs:
+        data.attrs.pop('stagger')
+    assert set(destaggered.attrs.keys()) == set(data.attrs.keys())
+
 
 @pytest.mark.parametrize('test_grid', ['lambert_conformal', 'mercator'], indirect=True)
 def test_dataarray_destagger_with_exclude(test_grid):
@@ -116,6 +121,7 @@ def test_dataset_destagger(test_grid):
         for key in ['stagger', 'units']:
             if key in test_grid[varname].attrs:
                 test_grid[varname].attrs.pop(key)
+        # because of xwrf.postprocess, the destaggered attrs will include more information
         assert set(test_grid[varname].attrs.keys()) <= set(destaggered[varname].attrs.keys())
 
     # Check that attrs are preserved

--- a/tests/test_accessors.py
+++ b/tests/test_accessors.py
@@ -80,9 +80,9 @@ def test_dataarray_destagger(test_grid):
     xr.testing.assert_allclose(destaggered['XLONG'], test_grid['XLONG'])
 
     # Check attributes are preserved
-    if 'stagger' in data.attrs:
-        data.attrs.pop('stagger')
-    assert set(destaggered.attrs.keys()) == set(data.attrs.keys())
+    assert set(destaggered.attrs.keys()) == set(data.attrs.keys()) - {
+        'stagger',
+    }
 
 
 @pytest.mark.parametrize('test_grid', ['lambert_conformal', 'mercator'], indirect=True)
@@ -117,12 +117,10 @@ def test_dataset_destagger(test_grid):
 
     # Check preservation of variable attrs
     for varname in set(test_grid.data_vars).intersection(set(destaggered.data_vars)):
-        # have to pop 'units' too, because dimensionless units have attr removed on postprocess
-        for key in ['stagger', 'units']:
-            if key in test_grid[varname].attrs:
-                test_grid[varname].attrs.pop(key)
         # because of xwrf.postprocess, the destaggered attrs will include more information
-        assert set(test_grid[varname].attrs.keys()) <= set(destaggered[varname].attrs.keys())
+        assert set(test_grid[varname].attrs.keys()) - {'stagger', 'units'} <= set(
+            destaggered[varname].attrs.keys()
+        )
 
     # Check that attrs are preserved
     assert destaggered.attrs == test_grid.attrs

--- a/tests/test_destagger.py
+++ b/tests/test_destagger.py
@@ -63,14 +63,16 @@ def test_destag_variable_multiple_dims():
     ],
 )
 def test_destag_variable_1d(unstag_dim_name, expected_output_dim_name):
-    staggered = xr.Variable(('bottom_top_stag',), np.arange(5), attrs={'stagger': 'Z'})
+    staggered = xr.Variable(
+        ('bottom_top_stag',), np.arange(5), attrs={'foo': 'bar', 'stagger': 'Z'}
+    )
     output = _destag_variable(staggered, unstag_dim_name=unstag_dim_name)
     # Check values
     np.testing.assert_array_almost_equal(output.values, 0.5 + np.arange(4))
     # Check dim name
     assert output.dims[0] == expected_output_dim_name
     # Check attrs
-    assert not output.attrs
+    assert output.attrs == {'foo': 'bar'}
 
 
 def test_destag_variable_2d():

--- a/xwrf/accessors.py
+++ b/xwrf/accessors.py
@@ -175,6 +175,7 @@ class WRFDatasetAccessor(WRFAccessor):
                 # Found a staggered dim
                 # TODO: should we raise an error if somehow end up with more than just one
                 # staggered dim, or just pick one from the set like below?
+                _attrs = var_data.attrs
                 this_staggered_dim = this_staggered_dims.pop()
                 new_data_vars[var_name] = _destag_variable(
                     var_data.variable,
@@ -185,6 +186,9 @@ class WRFDatasetAccessor(WRFAccessor):
                         else staggered_to_unstaggered_dims[this_staggered_dim]
                     ),
                 )
+                if 'stagger' in _attrs:
+                    _attrs.pop('stagger')
+                new_data_vars[var_name].attrs = _attrs
             else:
                 # No staggered dims
                 new_data_vars[var_name] = var_data.variable

--- a/xwrf/accessors.py
+++ b/xwrf/accessors.py
@@ -65,6 +65,7 @@ class WRFDataArrayAccessor(WRFAccessor):
         and/or use cases. For full accuracy, auxiliary coordinates should be re-computed from
         dimension coordinates or obtained from the original dataset.
         """
+        _attrs = self.xarray_obj.variable.attrs
         new_variable = _destag_variable(
             self.xarray_obj.variable, stagger_dim=stagger_dim, unstag_dim_name=unstaggered_dim_name
         )
@@ -86,7 +87,9 @@ class WRFDataArrayAccessor(WRFAccessor):
             else:
                 new_coords[coord_name] = coord_data.variable
 
-        return xr.DataArray(new_variable, coords=new_coords)
+        if 'stagger' in _attrs:
+            _attrs.pop('stagger')
+        return xr.DataArray(new_variable, coords=new_coords, attrs=_attrs)
 
 
 @xr.register_dataset_accessor('xwrf')

--- a/xwrf/accessors.py
+++ b/xwrf/accessors.py
@@ -65,7 +65,6 @@ class WRFDataArrayAccessor(WRFAccessor):
         and/or use cases. For full accuracy, auxiliary coordinates should be re-computed from
         dimension coordinates or obtained from the original dataset.
         """
-        _attrs = self.xarray_obj.variable.attrs
         new_variable = _destag_variable(
             self.xarray_obj.variable, stagger_dim=stagger_dim, unstag_dim_name=unstaggered_dim_name
         )
@@ -87,9 +86,7 @@ class WRFDataArrayAccessor(WRFAccessor):
             else:
                 new_coords[coord_name] = coord_data.variable
 
-        if 'stagger' in _attrs:
-            _attrs.pop('stagger')
-        return xr.DataArray(new_variable, coords=new_coords, attrs=_attrs)
+        return xr.DataArray(new_variable, coords=new_coords)
 
 
 @xr.register_dataset_accessor('xwrf')
@@ -178,7 +175,6 @@ class WRFDatasetAccessor(WRFAccessor):
                 # Found a staggered dim
                 # TODO: should we raise an error if somehow end up with more than just one
                 # staggered dim, or just pick one from the set like below?
-                _attrs = var_data.attrs
                 this_staggered_dim = this_staggered_dims.pop()
                 new_data_vars[var_name] = _destag_variable(
                     var_data.variable,
@@ -189,9 +185,6 @@ class WRFDatasetAccessor(WRFAccessor):
                         else staggered_to_unstaggered_dims[this_staggered_dim]
                     ),
                 )
-                if 'stagger' in _attrs:
-                    _attrs.pop('stagger')
-                new_data_vars[var_name].attrs = _attrs
             else:
                 # No staggered dims
                 new_data_vars[var_name] = var_data.variable

--- a/xwrf/destagger.py
+++ b/xwrf/destagger.py
@@ -74,7 +74,7 @@ def _destag_variable(datavar, stagger_dim=None, unstag_dim_name=None):
         dims=tuple(str(unstag_dim_name) if dim == stagger_dim else dim for dim in center_mean.dims),
         data=center_mean.data,
         attrs=_drop_attrs(datavar.attrs, ('stagger',)),
-        encoding=center_mean.encoding,
+        encoding=datavar.encoding,
         fastpath=True,
     )
 

--- a/xwrf/destagger.py
+++ b/xwrf/destagger.py
@@ -73,7 +73,7 @@ def _destag_variable(datavar, stagger_dim=None, unstag_dim_name=None):
     return xr.Variable(
         dims=tuple(str(unstag_dim_name) if dim == stagger_dim else dim for dim in center_mean.dims),
         data=center_mean.data,
-        attrs=_drop_attrs(center_mean.attrs, ('stagger',)),
+        attrs=_drop_attrs(datavar.attrs, ('stagger',)),
         encoding=center_mean.encoding,
         fastpath=True,
     )


### PR DESCRIPTION
<!-- Thanks for submitting a PR, your contribution is really appreciated! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

## Change Summary

When using the `destagger` method of `Dataset` and `DataArray` accessors, variable attributes were getting removed. Attributes like `units` or `grid_mapping` are however important for processing of data, e.g. with `metpy`.

## Related issue number

Closing #96 

## Checklist

- [x] Unit tests for the changes exist
- [x] Tests pass on CI
- [ ] ~~Documentation reflects the changes where applicable~~

<!--
Please add any other relevant info below:
-->
