### PR TITLE
Clean up _destag_variable with respect to types and terminology

### DIFF
--- a/tests/test_destagger.py
+++ b/tests/test_destagger.py
@@ -45,6 +45,15 @@ def test_rename_staggered_coordinate(input_name, stagger_dim, unstag_dim_name, o
     assert _rename_staggered_coordinate(input_name, stagger_dim, unstag_dim_name) == output_name
 
 
+def test_destag_variable_dataarray():
+    with pytest.raises(ValueError):
+        _destag_variable(xr.DataArray(
+            np.zeros((2, 2)),
+            dims=('x_stag', 'y'),
+            coords={'x_stag': [0, 1], 'y': [0, 1]}
+        ))
+
+
 def test_destag_variable_missing_dim():
     with pytest.raises(ValueError):
         _destag_variable(xr.Variable(('x', 'y'), np.zeros((2, 2))), 'z_stag')

--- a/tests/test_destagger.py
+++ b/tests/test_destagger.py
@@ -47,11 +47,11 @@ def test_rename_staggered_coordinate(input_name, stagger_dim, unstag_dim_name, o
 
 def test_destag_variable_dataarray():
     with pytest.raises(ValueError):
-        _destag_variable(xr.DataArray(
-            np.zeros((2, 2)),
-            dims=('x_stag', 'y'),
-            coords={'x_stag': [0, 1], 'y': [0, 1]}
-        ))
+        _destag_variable(
+            xr.DataArray(
+                np.zeros((2, 2)), dims=('x_stag', 'y'), coords={'x_stag': [0, 1], 'y': [0, 1]}
+            )
+        )
 
 
 def test_destag_variable_missing_dim():


### PR DESCRIPTION
<!-- Thanks for submitting a PR, your contribution is really appreciated! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

## Change Summary

<!-- Please give a short summary of the changes. -->

Further cleanups of #93 after merge (sorry about that!), this time to help out developers/contributors who wish to build upon the private `_destag_variable` function:

As discussed in https://github.com/xarray-contrib/xwrf/pull/100#discussion_r973392632 and https://github.com/xarray-contrib/xwrf/pull/100#discussion_r973399431, this adds a type check for `xarray.Variable` in `_destag_variable` as a safe guard for xwrf contributors against passing in an `xarray.DataArray` by accident. Also, updates comments in `_destag_variable` from the original version in #37 to have a bit more accurate terminology.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

## Checklist

- [x] Unit tests for the changes exist
- [ ] Tests pass on CI
- ~~Documentation reflects the changes where applicable~~

<!--
Please add any other relevant info below:
-->
