### PR TITLE
Clear c_grid_axis_shift from attrs when destaggering

### DIFF
--- a/tests/test_accessors.py
+++ b/tests/test_accessors.py
@@ -108,10 +108,11 @@ def test_dataarray_destagger_with_postprocess(test_grid):
     # Check staggered to unstaggered dimension coordinate handling
     xr.testing.assert_allclose(destaggered['x'], postprocessed['x'])
 
-    # Check attributes are preserved
+    # Check attributes are preserved, other than those made invalid by destaggering
     assert set(destaggered.attrs.keys()) == set(data.attrs.keys()) - {
         'stagger',
     }
+    assert 'c_grid_axis_shift' not in destaggered['x'].attrs
 
 
 @pytest.mark.parametrize('test_grid', ['lambert_conformal', 'mercator'], indirect=True)

--- a/xwrf/destagger.py
+++ b/xwrf/destagger.py
@@ -69,7 +69,7 @@ def _destag_variable(datavar, stagger_dim=None, unstag_dim_name=None):
     return xr.Variable(
         dims=tuple(str(unstag_dim_name) if dim == stagger_dim else dim for dim in center_mean.dims),
         data=center_mean.data,
-        attrs=_drop_attrs(datavar.attrs, ('stagger',)),
+        attrs=_drop_attrs(datavar.attrs, ('stagger', 'c_grid_axis_shift')),
         encoding=datavar.encoding,
         fastpath=True,
     )


### PR DESCRIPTION
<!-- Thanks for submitting a PR, your contribution is really appreciated! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

## Change Summary

Quick fix for primary issues mentioned in https://github.com/xarray-contrib/xwrf/issues/104 (i.e., that `c_grid_axis_shift` sticks around when using the DataArray destagger method where it shouldn't.

<!-- Please give a short summary of the changes. -->

## Related issue number

Part of #104, may or may not fully close yet. If discussion in #104 leads to more relevant changes, either this or a future PR can incorporate those changes.

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

## Checklist

- [x] Unit tests for the changes exist
- [ ] Tests pass on CI
- ~~Documentation reflects the changes where applicable~~

<!--
Please add any other relevant info below:
-->
