### PR TITLE
Fixed decoding of timestamp by using correct format string

### DIFF
--- a/xwrf/postprocess.py
+++ b/xwrf/postprocess.py
@@ -21,9 +21,7 @@ def _decode_times(ds: xr.Dataset) -> xr.Dataset:
             ds.Times.data.astype('str'), errors='raise', format='%Y-%m-%d_%H:%M:%S'
         )
     except ValueError:
-        _time = pd.to_datetime(
-            ds.Times.data.astype('str'), errors='raise', format='%Y-%m-%dT%H:%M:%S.%f'
-        )
+        _time = pd.to_datetime(ds.Times.data.astype('str'), errors='raise', format='ISO8601')
     ds = ds.assign_coords({'Time': _time})
     ds.Time.attrs = {'long_name': 'Time', 'standard_name': 'time'}
     # make XTIME be consistent with its description

--- a/xwrf/postprocess.py
+++ b/xwrf/postprocess.py
@@ -21,7 +21,9 @@ def _decode_times(ds: xr.Dataset) -> xr.Dataset:
             ds.Times.data.astype('str'), errors='raise', format='%Y-%m-%d_%H:%M:%S'
         )
     except ValueError:
-        _time = pd.to_datetime(ds.Times.data.astype('str'), errors='raise', format='ISO8601')
+        _time = pd.to_datetime(
+            ds.Times.data.astype('str'), errors='raise', format='%Y-%m-%dT%H:%M:%S'
+        )
     ds = ds.assign_coords({'Time': _time})
     ds.Time.attrs = {'long_name': 'Time', 'standard_name': 'time'}
     # make XTIME be consistent with its description


### PR DESCRIPTION
<!-- Thanks for submitting a PR, your contribution is really appreciated! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

## Change Summary

Fixed the issue in #127's CI by using the correct format string without milliseconds to decode the timestamps instead of using the format string. For some reason python 3.9 and 3.10 were able to also parse datetime strings without the milliseconds added but 3.8 was not.

## Related issue number

#127 

## Checklist

- [x] Unit tests for the changes exist
- [x] Tests pass on CI
- [x] Documentation reflects the changes where applicable

<!--
Please add any other relevant info below:
-->
