### PR TITLE
Added additional Exception when user is trying to destagger unstaggered variable

### DIFF
--- a/tests/test_destagger.py
+++ b/tests/test_destagger.py
@@ -46,12 +46,23 @@ def test_rename_staggered_coordinate(input_name, stagger_dim, unstag_dim_name, o
 
 
 def test_destag_variable_dataarray():
-    with pytest.raises(ValueError):
-        _destag_variable(
-            xr.DataArray(
-                np.zeros((2, 2)), dims=('x_stag', 'y'), coords={'x_stag': [0, 1], 'y': [0, 1]}
-            )
+    with pytest.raises(ValueError) as exc_info:
+        mock_da = xr.DataArray(
+            np.zeros((2, 2)), dims=('x_stag', 'y'), coords={'x_stag': [0, 1], 'y': [0, 1]}
         )
+        _destag_variable(mock_da)
+    assert (
+        exc_info.value.args[0] == f'Parameter datavar must be xarray.Variable, not {type(mock_da)}'
+    )
+
+
+def test_destag_variable_unstaggered():
+    with pytest.raises(ValueError) as exc_info:
+        _destag_variable(xr.Variable(('x', 'y'), np.zeros((2, 2))))
+    assert (
+        exc_info.value.args[0]
+        == 'No dimension available to destagger. This variable does not appear to be staggered.'
+    )
 
 
 def test_destag_variable_missing_dim():

--- a/xwrf/destagger.py
+++ b/xwrf/destagger.py
@@ -50,6 +50,11 @@ def _destag_variable(datavar, stagger_dim=None, unstag_dim_name=None):
                 'Expected a single destagger dimensions. Found multiple destagger dimensions: '
                 f'{stagger_dim}'
             )
+        elif len(stagger_dim) == 0:
+            raise ValueError(
+                'No dimension available to destagger. This variable does not appear to be '
+                'staggered.'
+            )
 
         # we need a string, not a list containing a string
         stagger_dim = stagger_dim[0]


### PR DESCRIPTION
<!-- Thanks for submitting a PR, your contribution is really appreciated! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

## Change Summary

We just add another Exception for the case a user is trying to destagger an unstaggered variable. Adding this additional `elif` only leaves the remaining condition `len(stagger_dim) == 1` continuing to execute.

## Related issue number

Closes #147 

## Checklist

- [x] Unit tests for the changes exist
- [x] Tests pass on CI
- [x] Documentation reflects the changes where applicable

<!--
Please add any other relevant info below:
-->
