### PR TITLE
Added test for raising of NotImplementedError on invalid MAP_PROJ

### DIFF
--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -41,7 +41,7 @@ def test_grid_construction_against_salem(dummy_dataset, dummy_salem):
 
 
 def test_raise_notimplemented_error(dummy_dataset):
-    dummy_dataset.attrs['MAP_PROJ'] = 'dummy'
+    dummy_dataset.attrs['MAP_PROJ'] = 'invalid'
     with pytest.raises(NotImplementedError):
         _wrf_grid_from_dataset(dummy_dataset)
 

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -40,6 +40,12 @@ def test_grid_construction_against_salem(dummy_dataset, dummy_salem):
     assert grid_params['crs'] == pyproj.CRS(dummy_salem['Q2'].attrs['pyproj_srs'])
 
 
+def test_raise_notimplemented_error(dummy_dataset):
+    dummy_dataset.attrs['MAP_PROJ'] = 'dummy'
+    with pytest.raises(NotImplementedError):
+        _wrf_grid_from_dataset(dummy_dataset)
+
+
 @pytest.mark.parametrize(
     'test_grid, cf_grid_mapping_name',
     [


### PR DESCRIPTION
<!-- Thanks for submitting a PR, your contribution is really appreciated! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

## Change Summary

Improved coverage by adding test checking that NotImplementedErrors are properly raised when encountering invalid (or not yet implemented) MAP_PROJ attrributes.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

## Checklist

- [x] Unit tests for the changes exist
- [x] Tests pass on CI
- [x] Documentation reflects the changes where applicable

<!--
Please add any other relevant info below:
-->
